### PR TITLE
@:nativeGen for HaxeProperties.hx

### DIFF
--- a/unihx/_internal/editor/HaxeProperties.hx
+++ b/unihx/_internal/editor/HaxeProperties.hx
@@ -8,6 +8,7 @@ import sys.FileSystem.*;
 
 using StringTools;
 
+@:nativeGen
 @:native('HaxeProperties')
 class HaxeProperties extends EditorWindow
 {


### PR DESCRIPTION
Fixes:

C:\Users\Matthew\Downloads\unihx-development\unihx-development\unihx\_internal\editor\HaxeProperties.hx(13,46): error CS0266: Cannot implicitly convert type `object' to`UnityEngine.Vector2'. An explicit conversion exists (are you missing a cast?)
